### PR TITLE
Feat Drone ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,11 +64,11 @@ steps:
       password:
         from_secret: GITHUB_PASSWORD
       tags: latest
-    # when:
-    #   event:
-    #     - push
-    #   branch:
-    #     - master
+    when:
+      event:
+        - push
+      branch:
+        - master
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -74,3 +74,4 @@ trigger:
   event:
     include:
       - push
+      - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,11 +64,11 @@ steps:
       password:
         from_secret: GITHUB_PASSWORD
       tags: latest
-    when:
-      event:
-        - push
-      branch:
-        - master
+    # when:
+    #   event:
+    #     - push
+    #   branch:
+    #     - master
 
 trigger:
   event:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
 FROM node:18
-LABEL org.opencontainers.image.source https://github.com/KevinMidboe/figlet-http
 
-RUN mkdir -p /opt/figlet-http/src
+RUN mkdir -p /opt/figlet-http/lib
 
 WORKDIR /opt/figlet-http
 
-# COPY src/ src
-# COPY tsconfig.json .
-# COPY package.json .
-# COPY yarn.lock .
-
+COPY package.json .
 COPY lib/ lib
-COPY node_modules/ node_modules
 
-# RUN yarn
-# RUN yarn build
+RUN yarn install --production
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ RUN mkdir -p /opt/figlet-http/src
 
 WORKDIR /opt/figlet-http
 
-COPY src/ src
-COPY tsconfig.json .
-COPY package.json .
-COPY yarn.lock .
+# COPY src/ src
+# COPY tsconfig.json .
+# COPY package.json .
+# COPY yarn.lock .
 
-RUN yarn
-RUN yarn build
+COPY lib/ lib
+COPY node_modules/ node_modules
+
+# RUN yarn
+# RUN yarn build
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY node_modules/ node_modules
 
 EXPOSE 3000
 
-CMD ["yarn", "start"]
+CMD ["node", "lib/app.js"]

--- a/README.md
+++ b/README.md
@@ -56,14 +56,25 @@ Api endpoints `/text` & `/motd` have the following query options:
 
 ## Docker install
 
-Run as a docker container using:
+Run as a docker container from github container registry:
 
 ```bash
-docker run -d \
+sudo docker run -d \
   --name figlet-http \
   -p 3000:3000 \
   ghcr.io/kevinmidboe/figlet-http
 ```
+
+Run as docker locally:
+```bash
+yarn build; \
+sudo docker build -t figlet-http .; \
+sudo docker run -d \
+  --name figlet-http \
+  -p 3000:3000 \
+  figlet-http
+```
+
 
 ## Systemd service
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "figlet": "^1.5.2",
-    "typescript": "^4.8.4"
+    "figlet": "^1.5.2"
   },
   "devDependencies": {
     "@types/node": "^18.11.2",
@@ -16,6 +15,7 @@
     "@typescript-eslint/parser": "^5.40.1",
     "eslint": "^8.25.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.26.0",
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Build and publish using Drone.

Changed Dockerfile to require build from outside before it copies in `/lib` contents. Then requires only non-development packages.